### PR TITLE
Bumb tf_label to version 0.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 
 # Local values for vars
 terraform.tfvars
+.idea/

--- a/README.md
+++ b/README.md
@@ -18,10 +18,12 @@ resource "aws_instance" "default" {
 ```
 module "tf_ami_from_instance" {
   source             = "git::https://github.com/cloudposse/tf_ami_from_instance.git?ref=master"
-  name               = "${aws_instance.web.id}"
   source_instance_id = "${aws_instance.web.id}"
   stage              = "${var.stage}"
   namespace          = "${var.namespace}"
+  name               = "${var.name}"
+  attributes         = "${var.attributes}"
+  tags               = "${var.tags}"
 }
 
 ```

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,7 @@ module "label" {
   stage      = "${var.stage}"
   name       = "${var.name}"
   attributes = "${var.attributes}"
+  delimeter  = "${var.delimiter}"
   tags       = "${var.tags}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,15 +1,17 @@
-module "tf_label" {
-  source    = "git::https://github.com/cloudposse/tf_label.git?ref=0.1.0"
-  namespace = "${var.namespace}"
-  stage     = "${var.stage}"
-  name      = "${var.name}"
+module "label" {
+  source     = "git::https://github.com/cloudposse/tf_label.git?ref=0.2.0"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  name       = "${var.name}"
+  attributes = "${var.attributes}"
+  tags       = "${var.tags}"
 }
 
 resource "aws_ami_from_instance" "default" {
-  name                    = "${module.tf_label.id}"
+  name                    = "${module.label.id}"
   source_instance_id      = "${var.source_instance_id}"
   snapshot_without_reboot = "${var.snapshot_without_reboot}"
-  tags                    = "${module.tf_label.tags}"
+  tags                    = "${module.label.tags}"
 
   lifecycle {
     create_before_destroy = true

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ module "label" {
   stage      = "${var.stage}"
   name       = "${var.name}"
   attributes = "${var.attributes}"
-  delimeter  = "${var.delimiter}"
+  delimiter  = "${var.delimiter}"
   tags       = "${var.tags}"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -2,6 +2,21 @@ variable "namespace" {}
 variable "stage" {}
 variable "name" {}
 variable "source_instance_id" {}
+
 variable "snapshot_without_reboot" {
   default = "true"
+}
+
+variable "delimiter" {
+  default = "-"
+}
+
+variable "attributes" {
+  type    = "list"
+  default = []
+}
+
+variable "tags" {
+  type    = "map"
+  default = {}
 }


### PR DESCRIPTION
## What
* Bump `tf_label` to version 0.2.0

## Why
* We need this feature to use additional tags for AMI of instances 
